### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,52 +1,37 @@
 {
-	"name"				: "grunt-static-hbs",
-	"version"			: "0.1.0",
-	"license"			: "Zlib",
-
-	"description"		: "Compile hbs templates into static html files",
-
-	"contributors" :
-	[
+	"name": "grunt-static-hbs",
+	"version": "0.1.0",
+	"license": "Zlib",
+	"description": "Compile hbs templates into static html files",
+	"contributors": [
 		{
-			"name"		: "David Krutsko",
-			"email"		: "dave@krutsko.net",
-			"url"		: "dave.krutsko.net"
+			"name": "David Krutsko",
+			"email": "dave@krutsko.net",
+			"url": "dave.krutsko.net"
 		}
 	],
-
-	"repository" :
-	{
-		"type"			: "git",
-		"url"			: "https://github.com/dkrutsko/grunt-static-hbs.git"
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/dkrutsko/grunt-static-hbs.git"
 	},
-
-	"bugs" :
-	{
-		"url"			: "https://github.com/dkrutsko/grunt-static-hbs/issues"
+	"bugs": {
+		"url": "https://github.com/dkrutsko/grunt-static-hbs/issues"
 	},
-
-	"keywords" :
-	[
+	"keywords": [
 		"handlebars",
 		"html",
 		"template",
 		"compiler",
 		"gruntplugin"
 	],
-
-	"dependencies" :
-	{
-		"hbs"			: "2.x.x",
-		"async"			: "0.x.x"
+	"dependencies": {
+		"hbs": "2.x.x",
+		"async": "0.x.x"
 	},
-
-	"peerDependencies" :
-	{
-		"grunt"			: "0.4.x"
+	"peerDependencies": {
+		"grunt": ">=0.4.0"
 	},
-
-	"engines" :
-	{
-		"node"			: ">= 0.10.0"
+	"engines": {
+		"node": ">= 0.10.0"
 	}
 }


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
